### PR TITLE
feat: show only pending TWIN

### DIFF
--- a/src/components/display/lp/LPCard.tsx
+++ b/src/components/display/lp/LPCard.tsx
@@ -74,12 +74,11 @@ const LPCard = ({ lp }: Props) => {
                 Pending TWIN
               </span>
               <div>
-                <i className="fa fa-unlock" /> {lp.unlockedTwin}{" "}
-                <small className="text-muted">({lp.unlockedTwinValue})</small>
-              </div>
-              <div>
-                <i className="fa fa-lock" /> {lp.lockedTwin}{" "}
-                <small className="text-muted">({lp.lockedTwinValue})</small>
+                {lp.unclaimedTwin}{" "}
+                <small style={{ fontWeight: 200 }}>TWIN</small>
+                <small className="text-muted d-block">
+                  ({lp.unclaimedTwinValue})
+                </small>
               </div>
             </div>
           </Col>

--- a/src/components/display/lp/LPTotalCard.tsx
+++ b/src/components/display/lp/LPTotalCard.tsx
@@ -1,11 +1,10 @@
 import { Card, Row, Col } from "react-bootstrap";
+import React from "react";
 
 interface Props {
   lp: {
-    unlockedTwin: string;
-    unlockedTwinValue: string;
-    lockedTwin: string;
-    lockedTwinValue: string;
+    unclaimedTwin: string;
+    unclaimedTwinValue: string;
     lpValue: string;
   };
 }
@@ -35,12 +34,11 @@ const LPTotalCard = ({ lp }: Props) => {
           >
             <div>
               <div>
-                <i className="fa fa-unlock" /> {lp.unlockedTwin}{" "}
-                <small className="text-muted">({lp.unlockedTwinValue})</small>
-              </div>
-              <div>
-                <i className="fa fa-lock" /> {lp.lockedTwin}{" "}
-                <small className="text-muted">({lp.lockedTwinValue})</small>
+                {lp.unclaimedTwin}{" "}
+                <small style={{ fontWeight: 200 }}>TWIN</small>
+                <small className="text-muted d-block">
+                  ({lp.unclaimedTwinValue})
+                </small>
               </div>
             </div>
           </Col>

--- a/src/modules/ethers/LiquidityPool.ts
+++ b/src/modules/ethers/LiquidityPool.ts
@@ -47,22 +47,6 @@ export interface LPPrice {
   token0Amount: string;
   token1Amount: string;
   lpAmount: string;
-  /**
-   * @deprecated Rewards no longer locked use unclaimedTwin instead
-   */
-  unlockedTwin: string;
-  /**
-   * @deprecated Rewards no longer locked use unclaimedTwinValue instead
-   */
-  unlockedTwinValue: string;
-  /**
-   * @deprecated Rewards no longer locked use unclaimedTwin instead
-   */
-  lockedTwin: string;
-  /**
-   * @deprecated Rewards no longer locked use unclaimedTwinValue instead
-   */
-  lockedTwinValue: string;
   lpValue: string;
   unformattedLpValue: any;
   pendingTwin: any;
@@ -103,14 +87,6 @@ const getDollyLPs = async (address: string): Promise<LPPrice[]> => {
         address
       );
       const twinPrice = await getTokenPriceWithDopPair(TOKENS.TWIN, dollyPrice);
-      const unlockedTwin = pendingTwin.mul(20).div(100);
-      const unlockedTwinValue = unlockedTwin
-        .mul(twinPrice)
-        .div(ethers.utils.parseEther("1"));
-      const lockedTwin = pendingTwin.mul(80).div(100);
-      const lockedTwinValue = lockedTwin
-        .mul(twinPrice)
-        .div(ethers.utils.parseEther("1"));
 
       const unclaimedTwinValue = pendingTwin
         .mul(twinPrice)
@@ -129,16 +105,6 @@ const getDollyLPs = async (address: string): Promise<LPPrice[]> => {
           lpAmount: new Intl.NumberFormat().format(
             parseFloat(Number(ethers.utils.formatEther(lpAmount)).toFixed(2))
           ),
-          unlockedTwin: new Intl.NumberFormat().format(
-            parseFloat(
-              Number(ethers.utils.formatEther(unlockedTwin)).toFixed(2)
-            )
-          ),
-          unlockedTwinValue: formatUsd(unlockedTwinValue),
-          lockedTwin: new Intl.NumberFormat().format(
-            parseFloat(Number(ethers.utils.formatEther(lockedTwin)).toFixed(2))
-          ),
-          lockedTwinValue: formatUsd(lockedTwinValue),
           lpValue: formatUsd(lpValue),
           unformattedLpValue: lpValue,
           pendingTwin,
@@ -208,14 +174,6 @@ const getDopLPs = async (address: string): Promise<LPPrice[]> => {
         address
       );
       const twinPrice = await getTokenPriceWithDopPair(TOKENS.TWIN, dollyPrice);
-      const unlockedTwin = pendingTwin.mul(20).div(100);
-      const unlockedTwinValue = unlockedTwin
-        .mul(twinPrice)
-        .div(ethers.utils.parseEther("1"));
-      const lockedTwin = pendingTwin.mul(80).div(100);
-      const lockedTwinValue = lockedTwin
-        .mul(twinPrice)
-        .div(ethers.utils.parseEther("1"));
 
       const unclaimedTwinValue = pendingTwin
         .mul(twinPrice)
@@ -234,16 +192,6 @@ const getDopLPs = async (address: string): Promise<LPPrice[]> => {
           lpAmount: new Intl.NumberFormat().format(
             parseFloat(Number(ethers.utils.formatEther(lpAmount)).toFixed(2))
           ),
-          unlockedTwin: new Intl.NumberFormat().format(
-            parseFloat(
-              Number(ethers.utils.formatEther(unlockedTwin)).toFixed(2)
-            )
-          ),
-          unlockedTwinValue: formatUsd(unlockedTwinValue),
-          lockedTwin: new Intl.NumberFormat().format(
-            parseFloat(Number(ethers.utils.formatEther(lockedTwin)).toFixed(2))
-          ),
-          lockedTwinValue: formatUsd(lockedTwinValue),
           lpValue: formatUsd(lpValue),
           unformattedLpValue: lpValue,
           pendingTwin,
@@ -275,14 +223,6 @@ export const getLPs = async (address: string) => {
 
   const dollyPrice = await getOracleDollyPrice();
   const twinPrice = await getTokenPriceWithDopPair(TOKENS.TWIN, dollyPrice);
-  const unlockedTwin = totalPendingTwins.mul(20).div(100);
-  const unlockedTwinValue = unlockedTwin
-    .mul(twinPrice)
-    .div(ethers.utils.parseEther("1"));
-  const lockedTwin = totalPendingTwins.mul(80).div(100);
-  const lockedTwinValue = lockedTwin
-    .mul(twinPrice)
-    .div(ethers.utils.parseEther("1"));
 
   const unclaimedTwinValue = totalPendingTwins
     .mul(twinPrice)
@@ -291,14 +231,6 @@ export const getLPs = async (address: string) => {
   return {
     lps: combineLPs,
     total: {
-      unlockedTwin: new Intl.NumberFormat().format(
-        parseFloat(Number(ethers.utils.formatEther(unlockedTwin)).toFixed(2))
-      ),
-      unlockedTwinValue: formatUsd(unlockedTwinValue),
-      lockedTwin: new Intl.NumberFormat().format(
-        parseFloat(Number(ethers.utils.formatEther(lockedTwin)).toFixed(2))
-      ),
-      lockedTwinValue: formatUsd(lockedTwinValue),
       lpValue: formatUsd(totalValue),
       unclaimedTwin: new Intl.NumberFormat().format(
         parseFloat(

--- a/src/modules/ethers/LiquidityPool.ts
+++ b/src/modules/ethers/LiquidityPool.ts
@@ -47,9 +47,21 @@ export interface LPPrice {
   token0Amount: string;
   token1Amount: string;
   lpAmount: string;
+  /**
+   * @deprecated Rewards no longer locked use unclaimedTwin instead
+   */
   unlockedTwin: string;
+  /**
+   * @deprecated Rewards no longer locked use unclaimedTwinValue instead
+   */
   unlockedTwinValue: string;
+  /**
+   * @deprecated Rewards no longer locked use unclaimedTwin instead
+   */
   lockedTwin: string;
+  /**
+   * @deprecated Rewards no longer locked use unclaimedTwinValue instead
+   */
   lockedTwinValue: string;
   lpValue: string;
   unformattedLpValue: any;

--- a/src/modules/ethers/LiquidityPool.ts
+++ b/src/modules/ethers/LiquidityPool.ts
@@ -66,6 +66,8 @@ export interface LPPrice {
   lpValue: string;
   unformattedLpValue: any;
   pendingTwin: any;
+  unclaimedTwin: string;
+  unclaimedTwinValue: string;
 }
 
 const getDollyLPs = async (address: string): Promise<LPPrice[]> => {
@@ -110,6 +112,10 @@ const getDollyLPs = async (address: string): Promise<LPPrice[]> => {
         .mul(twinPrice)
         .div(ethers.utils.parseEther("1"));
 
+      const unclaimedTwinValue = pendingTwin
+        .mul(twinPrice)
+        .div(ethers.utils.parseEther("1"));
+
       if (lpAmount.gt(0)) {
         return {
           token0Symbol: token,
@@ -136,6 +142,10 @@ const getDollyLPs = async (address: string): Promise<LPPrice[]> => {
           lpValue: formatUsd(lpValue),
           unformattedLpValue: lpValue,
           pendingTwin,
+          unclaimedTwin: new Intl.NumberFormat().format(
+            parseFloat(Number(ethers.utils.formatEther(pendingTwin)).toFixed(2))
+          ),
+          unclaimedTwinValue: formatUsd(unclaimedTwinValue),
         };
       } else {
         return undefined;
@@ -207,6 +217,10 @@ const getDopLPs = async (address: string): Promise<LPPrice[]> => {
         .mul(twinPrice)
         .div(ethers.utils.parseEther("1"));
 
+      const unclaimedTwinValue = pendingTwin
+        .mul(twinPrice)
+        .div(ethers.utils.parseEther("1"));
+
       if (lpAmount.gt(0)) {
         return {
           token0Symbol: token,
@@ -233,6 +247,10 @@ const getDopLPs = async (address: string): Promise<LPPrice[]> => {
           lpValue: formatUsd(lpValue),
           unformattedLpValue: lpValue,
           pendingTwin,
+          unclaimedTwin: new Intl.NumberFormat().format(
+            parseFloat(Number(ethers.utils.formatEther(pendingTwin)).toFixed(2))
+          ),
+          unclaimedTwinValue,
         };
       } else {
         return undefined;
@@ -266,6 +284,10 @@ export const getLPs = async (address: string) => {
     .mul(twinPrice)
     .div(ethers.utils.parseEther("1"));
 
+  const unclaimedTwinValue = totalPendingTwins
+    .mul(twinPrice)
+    .div(ethers.utils.parseEther("1"));
+
   return {
     lps: combineLPs,
     total: {
@@ -278,6 +300,12 @@ export const getLPs = async (address: string) => {
       ),
       lockedTwinValue: formatUsd(lockedTwinValue),
       lpValue: formatUsd(totalValue),
+      unclaimedTwin: new Intl.NumberFormat().format(
+        parseFloat(
+          Number(ethers.utils.formatEther(totalPendingTwins)).toFixed(2)
+        )
+      ),
+      unclaimedTwinValue: formatUsd(unclaimedTwinValue),
     },
   };
 };


### PR DESCRIPTION
Since bonus and reward lock period has ended users can now claim full amount of their earned rewards. Separating in unlocked/locked TWIN is no longer necessary.